### PR TITLE
Create Browser in CefNet.Avalonia.WebView when attached to logical tree

### DIFF
--- a/AvaloniaApp/MainWindow.xaml.cs
+++ b/AvaloniaApp/MainWindow.xaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Threading;
+using Avalonia.LogicalTree;
 using CefNet;
 using CefNet.Avalonia;
 using CefNet.JSInterop;
@@ -85,19 +86,7 @@ namespace AvaloniaApp
 			isFirstLoad = false;
 
 			AddTab(true);
-
-			// note: Below demonstrates that WebView cannot navigate immediately after creation.
-			// Trying this causes an InvalidOperationException to be thrown. Navgiation (and other tasks)
-			// require waiting until the BrowserCreated event has fired.
-			try
-			{
-				SelectedView?.Navigate("https://google.com");
-			}
-			catch (InvalidOperationException ioe)
-			{
-				Console.WriteLine("Cannot navgiate before browser is initialized:");
-				Console.WriteLine(ioe.Message);
-			}
+			SelectedView?.Navigate("https://google.com");			
 		}
 
 		private void MainWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e)

--- a/AvaloniaApp/MainWindow.xaml.cs
+++ b/AvaloniaApp/MainWindow.xaml.cs
@@ -85,6 +85,19 @@ namespace AvaloniaApp
 			isFirstLoad = false;
 
 			AddTab(true);
+
+			// note: Below demonstrates that WebView cannot navigate immediately after creation.
+			// Trying this causes an InvalidOperationException to be thrown. Navgiation (and other tasks)
+			// require waiting until the BrowserCreated event has fired.
+			try
+			{
+				SelectedView?.Navigate("https://google.com");
+			}
+			catch (InvalidOperationException ioe)
+			{
+				Console.WriteLine("Cannot navgiate before browser is initialized:");
+				Console.WriteLine(ioe.Message);
+			}
 		}
 
 		private void MainWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e)

--- a/CefNet/WebView.CommonImplementation.cs
+++ b/CefNet/WebView.CommonImplementation.cs
@@ -1,4 +1,4 @@
-﻿using CefNet.Input;
+using CefNet.Input;
 using CefNet.Internal;
 
 
@@ -286,7 +286,12 @@ namespace CefNet
 
 		protected CefBrowser AliveBrowserObject
 		{
-			get { return BrowserObject; }
+			get {
+				if (!GetState(State.Created))
+					throw new InvalidOperationException("WebView.AliveBrowserObject instance is not yet initialized. Calls that require the browser instance can only be made after the BrowserCreated event has fired.");
+				System.Diagnostics.Debug.Assert(BrowserObject != null);
+				return BrowserObject;
+			}
 		}
 
 		protected CefBrowserHost AliveBrowserHost
@@ -324,7 +329,7 @@ namespace CefNet
 		{
 			get
 			{
-				return AliveBrowserObject.CanGoBack;
+				return BrowserObject?.CanGoBack ?? false;
 			}
 		}
 
@@ -336,9 +341,9 @@ namespace CefNet
 		/// </returns>
 		public bool GoBack()
 		{
-			CefBrowser browser = AliveBrowserObject;
-			if (!browser.CanGoBack)
+			if (!CanGoBack)
 				return false;
+			CefBrowser browser = AliveBrowserObject;
 			browser.GoBack();
 			GC.KeepAlive(browser);
 			return true;
@@ -352,7 +357,7 @@ namespace CefNet
 		{
 			get
 			{
-				return AliveBrowserObject.CanGoForward;
+				return BrowserObject?.CanGoForward ?? false;
 			}
 		}
 
@@ -364,9 +369,9 @@ namespace CefNet
 		/// </returns>
 		public bool GoForward()
 		{
-			CefBrowser browser = AliveBrowserObject;
-			if (!browser.CanGoForward)
+			if (!CanGoForward)
 				return false;
+			CefBrowser browser = AliveBrowserObject;
 			browser.GoForward();
 			GC.KeepAlive(browser);
 			return true;
@@ -380,7 +385,7 @@ namespace CefNet
 		{
 			get
 			{
-				return AliveBrowserObject.IsLoading;
+				return BrowserObject?.IsLoading ?? false;
 			}
 		}
 
@@ -426,7 +431,7 @@ namespace CefNet
 		{
 			get
 			{
-				return AliveBrowserObject.HasDocument;
+				return BrowserObject?.HasDocument ?? false;
 			}
 		}
 


### PR DESCRIPTION
Fixes #92 . Creation of the browser object in CefNet.Avalonia.WebView now happens when attached to the logical tree (rooted at a `Avalonia.Controls.Window`) instead of only at first layouting/drawing pass.